### PR TITLE
Make tests more independent of test data

### DIFF
--- a/test/util/quote_test.dart
+++ b/test/util/quote_test.dart
@@ -1,20 +1,24 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:pocket_scat/util/injected_things.dart';
+import 'package:pocket_scat/util/quote_category.dart';
 import 'package:pocket_scat/util/quote_source.dart';
 import 'package:pocket_scat/util/quote.dart';
 
 import 'mocks.dart';
 
 void main() {
+  const sourceA = QuoteSource('Toast of London', QuoteCategory.SITCOM, 'toast');
+  const sourceB = QuoteSource('Rainbow', QuoteCategory.KIDS_TV, 'rainbow');
+
   group('search', () {
     test('should always contain an empty search', () {
-      const quote = Quote('file_name', 'bar', SRC_TOAST, '');
+      const quote = Quote('file_name', 'bar', sourceA, '');
       expect(quote.containsSearchTerm(''), true);
     });
 
     test('should be searchable by name', () {
-      const quote = Quote('file_name', 'Some Text', SRC_TOAST, '');
+      const quote = Quote('file_name', 'Some Text', sourceA, '');
       expect(quote.containsSearchTerm('Some Text'), true);
       expect(quote.containsSearchTerm('sOmE tExT'), true);
       expect(quote.containsSearchTerm('some'), true);
@@ -23,7 +27,7 @@ void main() {
     });
 
     test('should be searchable by search string', () {
-      const quote = Quote('file_name', 'Some Text', SRC_TOAST, 'the quote is actually this');
+      const quote = Quote('file_name', 'Some Text', sourceA, 'the quote is actually this');
       expect(quote.containsSearchTerm('the quote is actually this'), true);
       expect(quote.containsSearchTerm('aCtUALLy'), true);
       expect(quote.containsSearchTerm('tual'), true);
@@ -31,7 +35,7 @@ void main() {
     });
 
     test('should be searchable by quote source', () {
-      const quote = Quote('file_name', 'Some Text', SRC_TOAST, '');
+      const quote = Quote('file_name', 'Some Text', sourceA, '');
       expect(quote.containsSearchTerm('toast of london'), true);
       expect(quote.containsSearchTerm('curb'), false);
     });
@@ -39,14 +43,14 @@ void main() {
 
   group('getImage', () {
     test('should return its own image path if one is specified', () {
-      const quote = Quote('file_name', 'Some text', SRC_TOAST, 'some search terms', 'my_custom_image');
+      const quote = Quote('file_name', 'Some text', sourceA, 'some search terms', 'my_custom_image');
       final img = quote.getImage();
 
       expect(img.keyName, 'assets/images/my_custom_image.png');
     });
 
     test('should fall back on source image path if not specified', () {
-      const quote = Quote('file_name', 'Some text', SRC_TOAST, 'some search terms');
+      const quote = Quote('file_name', 'Some text', sourceA, 'some search terms');
       final img = quote.getImage();
 
       expect(img.keyName, 'assets/images/toast.png');
@@ -55,7 +59,7 @@ void main() {
 
   group('playback', () {
     test('should play the associated audio file', () async {
-      const quote = Quote('file_name', 'Some text', SRC_TOAST, '');
+      const quote = Quote('file_name', 'Some text', sourceA, '');
       audioCache = MockAudioCache();
       await quote.play();
 
@@ -64,8 +68,8 @@ void main() {
     });
 
     test('should stop the previous audio player if it exists before playing a new sound', () async {
-      const quoteOne = Quote('file_name', 'Some text', SRC_TOAST, '');
-      const quoteTwo = Quote('other_file', 'Other text', SRC_RAINBOW, '');
+      const quoteOne = Quote('file_name', 'Some text', sourceA, '');
+      const quoteTwo = Quote('other_file', 'Other text', sourceB, '');
 
       audioCache = MockAudioCache();
       final audioPlayer = MockAudioPlayer();
@@ -84,7 +88,7 @@ void main() {
 
   group('sharing', () {
     test('should share the audio file', () async {
-      const quote = Quote('file_name', 'Some text', SRC_TOAST, '');
+      const quote = Quote('file_name', 'Some text', sourceA, '');
       final buildContext = MockBuildContext();
       fileSharer = MockFileSharer();
 

--- a/test/widget/app_test.dart
+++ b/test/widget/app_test.dart
@@ -18,7 +18,7 @@ void main() {
     await tester.tap(find.byIcon(Icons.search));
     await tester.pump();
 
-    await tester.enterText(find.byType(TextField), quoteB.name);
+    await tester.enterText(find.byType(TextField), quoteB.name.substring(2));
     await tester.pump();
 
     // Verify that our search has been applied

--- a/test/widget/app_test.dart
+++ b/test/widget/app_test.dart
@@ -1,42 +1,36 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pocket_scat/util/quote.dart';
-import 'package:pocket_scat/util/quote_source.dart';
+import 'package:pocket_scat/util/quotes_list.dart';
 import 'package:pocket_scat/widget/app.dart';
 
-const PIECE_OF_YOUR_BRAIN = Quote(
-    'fawlty_piece_of_your_brain', 'Piece of your brain', SRC_FAWLTY_TOWERS, 'Is this a piece of your brain Basil');
-const ERRONEOUS_DISH =
-    Quote('fawlty_erroneous_dish', 'Erroneous dish', SRC_FAWLTY_TOWERS, 'I have been given an erroneous dish');
-const VERY_NICE_BRIAN = Quote('bean_very_nice_brian', 'Very nice Brian', SRC_BEAN, 'very nice brian');
-const BAD_MISS = Quote('mitchell_bad_miss_1', 'Bad Miss 1', SRC_MITCHELL_AND_WEBB, 'Oh and thats a bad miss');
-
-const TEST_QUOTES = [PIECE_OF_YOUR_BRAIN, ERRONEOUS_DISH, VERY_NICE_BRIAN, BAD_MISS];
+final testQuotes = ALL_QUOTES.sublist(0, 5);
+final quoteA = testQuotes[0];
+final quoteB = testQuotes[1];
 
 void main() {
   testWidgets('Should search quotes, and clear the search when cancelled', (WidgetTester tester) async {
-    await tester.pumpWidget(const App(TEST_QUOTES));
+    await tester.pumpWidget(App(testQuotes));
 
-    expect(find.text('Erroneous dish'), findsOneWidget);
-    expect(find.text('Piece of your brain'), findsOneWidget);
+    expect(find.text(quoteA.name), findsOneWidget);
+    expect(find.text(quoteB.name), findsOneWidget);
 
     // Tap the search icon and enter text
     await tester.tap(find.byIcon(Icons.search));
     await tester.pump();
 
-    await tester.enterText(find.byType(TextField), 'piece');
+    await tester.enterText(find.byType(TextField), quoteB.name);
     await tester.pump();
 
     // Verify that our search has been applied
-    expect(find.text('Erroneous dish'), findsNothing);
-    expect(find.text('Piece of your brain'), findsOneWidget);
+    expect(find.text(quoteA.name), findsNothing);
+    expect(find.text(quoteB.name), findsOneWidget);
 
     // Close the search
     await tester.tap(find.byIcon(Icons.close));
     await tester.pump();
 
     // Search should be cancelled
-    expect(find.text('Erroneous dish'), findsOneWidget);
-    expect(find.text('Piece of your brain'), findsOneWidget);
+    expect(find.text(quoteA.name), findsOneWidget);
+    expect(find.text(quoteB.name), findsOneWidget);
   });
 }


### PR DESCRIPTION
Resolves #15 as best I could. There'll still be a bit of churn if `QuoteCategory` is changed, but at least individual sources/quotes no longer matter for the tests.